### PR TITLE
Fix empty comment lines

### DIFF
--- a/sql/test.sql
+++ b/sql/test.sql
@@ -235,4 +235,7 @@ CREATE TABLE test_filtered_multiget(
   column_b BIGINT NOT NULL REFERENCES test_fk_2(id)
 );
 
+-- the next line is an empty comment, which breaks things
+--
+
 -- comments at the end seem to break things sometimes

--- a/src/main/scala/mdmoss/doobiegen/ParserUtils.scala
+++ b/src/main/scala/mdmoss/doobiegen/ParserUtils.scala
@@ -6,7 +6,7 @@ object ParserUtils {
 
   implicit class SqlStringHelpers(sql: String) {
     def stripComments: String = {
-      """--[^\n]+(\n)?""".r.replaceAllIn(sql, "")
+      """--[^\n]*(\n)?""".r.replaceAllIn(sql, "")
     }
 
     def splitOnUnescapedSemicolons: Seq[String] = {


### PR DESCRIPTION
```--
Invalid input '-', expected AlterSequence, With, Update, Commit, CreateTable, Begin, CreateExtension, DropView, Delete, DropTable, CreateView, CreateSchema, Insert, CreateIndex or AlterTable (line 1, column 1):
--
^
[error] (run-main-0) ParseError(Position(0,1,1), Position(0,1,1), <23 traces>)
ParseError(Position(0,1,1), Position(0,1,1), <23 traces>)
	at org.parboiled2.Parser.done$1(Parser.scala:185)
	at org.parboiled2.Parser.phase4_collectRuleTraces$1(Parser.scala:196)
	at org.parboiled2.Parser.__run(Parser.scala:209)
	at mdmoss.doobiegen.Runner$$anonfun$run$2.apply(Runner.scala:114)
	at mdmoss.doobiegen.Runner$$anonfun$run$2.apply(Runner.scala:111)
	at scala.collection.immutable.List.foreach(List.scala:381)
	at mdmoss.doobiegen.Runner$.run(Runner.scala:111)
	at mdmoss.doobiegen.TestGen$.main(TestGen.scala:56)
	at mdmoss.doobiegen.TestGen.main(TestGen.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)```