### PR TITLE
 Handle CREATE UNLOGGED TABLE

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.1.6

--- a/sql/test.sql
+++ b/sql/test.sql
@@ -235,6 +235,10 @@ CREATE TABLE test_filtered_multiget(
   column_b BIGINT NOT NULL REFERENCES test_fk_2(id)
 );
 
+CREATE UNLOGGED TABLE test_unlogged_table(
+  id BIGSERIAL PRIMARY KEY
+);
+
 -- the next line is an empty comment, which breaks things
 --
 

--- a/src/main/scala/mdmoss/doobiegen/SqlStatementParser.scala
+++ b/src/main/scala/mdmoss/doobiegen/SqlStatementParser.scala
@@ -26,7 +26,7 @@ class SqlStatementParser(val input: ParserInput) extends Parser {
   )
 
   def CreateTable: Rule1[sql.Statement] = rule {
-    ("CREATE TABLE " ~ optional("IF NOT EXISTS ") ~ TableRef ~ '(' ~ OptionalWhitespace ~ zeroOrMore(TableProperty) ~ ");") ~>
+    ("CREATE "  ~ optional("UNLOGGED ") ~ "TABLE " ~ optional("IF NOT EXISTS ") ~ TableRef ~ '(' ~ OptionalWhitespace ~ zeroOrMore(TableProperty) ~ ");") ~>
        { (ref, columns) => sql.CreateTable(ref, columns) }
   }
 


### PR DESCRIPTION
Parse 'UNLOGGED' optionally and throw it away.

doobie-codegen shouldn't care whether a table is logged or unlogged.